### PR TITLE
chore: moves naming to zodTimeString

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ This package has the following peer dependencies:
 ## Usage
 
 ```typescript
-import { timeStringSchema } from '@state303/zod-time-string';
+import zts from '@state303/zod-time-string';
 
 // Parse time strings to milliseconds
-const milliseconds = timeStringSchema.parse('5m');  // 300000 (5 minutes in ms)
+const milliseconds = zodTimeString.parse('5m');  // 300000 (5 minutes in ms)
 
 // Handles various formats
-timeStringSchema.parse('1h');      // 3600000 (1 hour in ms)
-timeStringSchema.parse('1.5d');    // 129600000 (1.5 days in ms)
-timeStringSchema.parse('100ms');   // 100 (100 milliseconds)
-timeStringSchema.parse('2.5 hrs'); // 9000000 (2.5 hours in ms)
+zts.parse('1h');      // 3600000 (1 hour in ms)
+zts.parse('1.5d');    // 129600000 (1.5 days in ms)
+zts.parse('100ms');   // 100 (100 milliseconds)
+zts.parse('2.5 hrs'); // 9000000 (2.5 hours in ms)
 
 // Numbers without units are interpreted as milliseconds
-timeStringSchema.parse('1000');    // 1000 (milliseconds)
+zts.parse('1000');    // 1000 (milliseconds)
 
 // Will throw for invalid formats
 try {
-  timeStringSchema.parse('abc');
-  timeStringSchema.parse('5z');    // Invalid unit
+  zts.parse('abc');
+  zts.parse('5z');    // Invalid unit
 } catch (error) {
   // Handle validation errors
 }
@@ -56,12 +56,16 @@ try {
 
 ## API
 
-### `timeStringSchema`
+### `zodTimeString`
 
 The main export is a Zod schema that validates and transforms time strings.
 
 ```typescript
-import { timeStringSchema } from 'zod-time-string';
+import { zodTimeString } from '@state303/zod-time-string';
+
+// OR
+
+import zts from '@state303/zod-time-string'
 ```
 
 Input: String containing a number with an optional time unit.
@@ -77,7 +81,7 @@ Validates that the parsed value is positive (greater than 0).
 
 ```typescript
 // Validates that the time is positive
-const schema = timeStringSchema.positive();
+const schema = zodTimeString.positive();
 schema.parse('5m');       // 300000 (valid)
 schema.parse('0ms');      // throws error (zero is not positive)
 schema.parse('-1h');      // throws error (negative)
@@ -89,7 +93,7 @@ Validates that the parsed value is negative (less than 0).
 
 ```typescript
 // Validates that the time is negative
-const schema = timeStringSchema.negative();
+const schema = zodTimeString.negative();
 schema.parse('-5m');      // -300000 (valid)
 schema.parse('0ms');      // throws error (zero is not negative)
 schema.parse('1h');       // throws error (positive)
@@ -101,7 +105,7 @@ Validates that the parsed value is greater than or equal to the specified minimu
 
 ```typescript
 // Validates that the time is at least 1 second (1000ms)
-const schema = timeStringSchema.min(1000);
+const schema = zodTimeString.min(1000);
 schema.parse('1s');       // 1000 (valid - equal to min)
 schema.parse('5s');       // 5000 (valid - greater than min)
 schema.parse('500ms');    // throws error (less than min)
@@ -113,7 +117,7 @@ Validates that the parsed value is less than or equal to the specified maximum (
 
 ```typescript
 // Validates that the time is at most 1 minute (60000ms)
-const schema = timeStringSchema.max(60000);
+const schema = zodTimeString.max(60000);
 schema.parse('1m');       // 60000 (valid - equal to max)
 schema.parse('30s');      // 30000 (valid - less than max)
 schema.parse('2m');       // throws error (greater than max)
@@ -128,7 +132,7 @@ The validation methods can be chained together to create complex validation rule
 // 1. Positive
 // 2. At least 1 second (1000ms)
 // 3. At most 1 hour (3600000ms)
-const schema = timeStringSchema
+const schema = zodTimeString
   .positive()
   .min(1000)
   .max(3600000);
@@ -150,26 +154,28 @@ You can customize error messages for all validations to better fit your applicat
 Use the `withErrorMessages` method to customize error messages for the basic validations:
 
 ```typescript
-const schema = timeStringSchema.withErrorMessages({
+import zts from '@state303/zod-time-string';
+
+const schema = zts.withErrorMessages({
   invalidFormatError: 'The time format is invalid',
   invalidValueError: 'The time value is invalid',
   invalidUnitError: 'The time unit is not recognized',
 });
 
 // Or with object format for more options
-const schema2 = timeStringSchema.withErrorMessages({
+const schema2 = zts.withErrorMessages({
   invalidFormatError: { message: 'The time format is invalid' },
   invalidUnitError: { message: 'The time unit is not recognized' },
 });
 
 // With function-based format for dynamic error messages
-const schema3 = timeStringSchema.withErrorMessages({
+const schema3 = zts.withErrorMessages({
   invalidFormatError: (invalid) => `"${invalid}" is not a valid time format`,
   invalidUnitError: (unitStr) => `Unit "${unitStr}" is not supported`,
 });
 
 // Or with function in object format
-const schema4 = timeStringSchema.withErrorMessages({
+const schema4 = zts.withErrorMessages({
   invalidFormatError: { 
     message: (invalid) => `Could not parse "${invalid}" as a time string` 
   }
@@ -182,24 +188,25 @@ Each chainable validation method accepts a custom error message parameter:
 
 ```typescript
 // With string format
-const schema = timeStringSchema
+import zts from '@state303/zod-time-string';
+const schema = zts
   .positive('Value must be greater than zero')
   .min(1000, 'Value must be at least 1 second')
   .max(3600000, 'Value must be at most 1 hour');
 
 // Or with object format
-const schema2 = timeStringSchema
+const schema2 = zts
   .positive({ message: 'Value must be greater than zero' })
   .min(1000, { message: 'Value must be at least 1 second' });
 
 // With function-based error messages for dynamic formatting
-const schema3 = timeStringSchema
+const schema3 = zts
   .positive((invalidValue) => `Value ${invalidValue} must be positive`)
   .min(1000, (invalidValue) => `Value ${invalidValue} is below the minimum of 1000ms`)
   .max(60000, (invalidValue) => `Value ${invalidValue} exceeds the maximum of 1 minute`);
 
 // Function-based messages can also be used within objects
-const schema4 = timeStringSchema
+const schema4 = zts
   .positive({ 
     message: (value) => `Expected a positive value, but got ${value}` 
   });
@@ -250,21 +257,21 @@ The schema supports a wide variety of time formats:
 
 ```typescript
 // Basic usage
-timeStringSchema.parse('100ms');   // 100
-timeStringSchema.parse('1s');      // 1000
-timeStringSchema.parse('5m');      // 300000
-timeStringSchema.parse('2h');      // 7200000
-timeStringSchema.parse('1d');      // 86400000
-timeStringSchema.parse('1mo');     // 2592000000
-timeStringSchema.parse('1y');      // 31536000000
+zodTimeString.parse('100ms');   // 100
+zodTimeString.parse('1s');      // 1000
+zodTimeString.parse('5m');      // 300000
+zodTimeString.parse('2h');      // 7200000
+zodTimeString.parse('1d');      // 86400000
+zodTimeString.parse('1mo');     // 2592000000
+zodTimeString.parse('1y');      // 31536000000
 
 // Edge cases
-timeStringSchema.parse('1.5h');    // 5400000 (1.5 hours)
-timeStringSchema.parse('0.5d');    // 43200000 (half day)
-timeStringSchema.parse('.5m');     // 30000 (half minute)
-timeStringSchema.parse('-1h');     // -3600000 (negative 1 hour)
-timeStringSchema.parse('  5  h  '); // 18000000 (whitespace handled)
-timeStringSchema.parse('5M');      // 300000 (case insensitive)
+zodTimeString.parse('1.5h');    // 5400000 (1.5 hours)
+zodTimeString.parse('0.5d');    // 43200000 (half day)
+zodTimeString.parse('.5m');     // 30000 (half minute)
+zodTimeString.parse('-1h');     // -3600000 (negative 1 hour)
+zodTimeString.parse('  5  h  '); // 18000000 (whitespace handled)
+zodTimeString.parse('5M');      // 300000 (case insensitive)
 ```
 
 ## License

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -287,4 +287,6 @@ function createTimeStringSchema( schema: z.ZodType<number>, options?: TimeString
 }
 
 // Export the enhanced schema with chainable methods
-export const timeStringSchema = createTimeStringSchema( baseTimeStringSchema );
+export const zodTimeString = createTimeStringSchema( baseTimeStringSchema );
+
+export default zodTimeString;

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -4,21 +4,21 @@
  */
 
 // Import from the dist directory (the built output)
-import { timeStringSchema } from '../dist';
+import { zodTimeString } from '../dist';
 
-describe('timeStringSchema integration', () => {
+describe('zodTimeString integration', () => {
   // Basic functionality test
   test('should parse time strings from the built package', () => {
     // Test a few basic time formats
-    expect(timeStringSchema.parse('5m')).toBe(300000);
-    expect(timeStringSchema.parse('1h')).toBe(3600000);
-    expect(timeStringSchema.parse('1.5d')).toBe(129600000);
-    expect(timeStringSchema.parse('100ms')).toBe(100);
+    expect(zodTimeString.parse('5m')).toBe(300000);
+    expect(zodTimeString.parse('1h')).toBe(3600000);
+    expect(zodTimeString.parse('1.5d')).toBe(129600000);
+    expect(zodTimeString.parse('100ms')).toBe(100);
   });
 
   // Test chainable methods
   test('should support chainable validation methods from the built package', () => {
-    const schema = timeStringSchema.positive().min(1000).max(3600000);
+    const schema = zodTimeString.positive().min(1000).max(3600000);
     
     // Valid cases
     expect(schema.parse('30s')).toBe(30000);
@@ -34,7 +34,7 @@ describe('timeStringSchema integration', () => {
   // Test custom error messages
   test('should support custom error messages from the built package', () => {
     const customMsg = 'Invalid time format';
-    const schema = timeStringSchema.withErrorMessages({
+    const schema = zodTimeString.withErrorMessages({
       invalidFormatError: customMsg
     });
 

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -1,122 +1,122 @@
-import { timeStringSchema } from '../lib';
+import { zodTimeString } from '../lib';
 
 describe( 'timeStringSchema', () => {
     describe( 'basic validation', () => {
         test( 'should parse valid time strings with units', () => {
-            expect( timeStringSchema.parse( '100ms' ) ).toBe( 100 );
-            expect( timeStringSchema.parse( '1s' ) ).toBe( 1000 );
-            expect( timeStringSchema.parse( '5m' ) ).toBe( 300000 );
-            expect( timeStringSchema.parse( '2h' ) ).toBe( 7200000 );
-            expect( timeStringSchema.parse( '1d' ) ).toBe( 86400000 );
-            expect( timeStringSchema.parse( '1mo' ) ).toBe( 2592000000 );
-            expect( timeStringSchema.parse( '1y' ) ).toBe( 31536000000 );
+            expect( zodTimeString.parse( '100ms' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '1s' ) ).toBe( 1000 );
+            expect( zodTimeString.parse( '5m' ) ).toBe( 300000 );
+            expect( zodTimeString.parse( '2h' ) ).toBe( 7200000 );
+            expect( zodTimeString.parse( '1d' ) ).toBe( 86400000 );
+            expect( zodTimeString.parse( '1mo' ) ).toBe( 2592000000 );
+            expect( zodTimeString.parse( '1y' ) ).toBe( 31536000000 );
         } );
 
         test( 'should parse numbers as milliseconds', () => {
-            expect( timeStringSchema.parse( '100' ) ).toBe( 100 );
-            expect( timeStringSchema.parse( '1000' ) ).toBe( 1000 );
+            expect( zodTimeString.parse( '100' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '1000' ) ).toBe( 1000 );
         } );
 
         test( 'should handle whitespace', () => {
-            expect( timeStringSchema.parse( ' 100ms ' ) ).toBe( 100 );
-            expect( timeStringSchema.parse( '  5  h  ' ) ).toBe( 18000000 );
-            expect( timeStringSchema.parse( '  1000  ' ) ).toBe( 1000 );
-            expect( timeStringSchema.parse( '   1000000' ) ).toBe( 1000000 );
-            expect( timeStringSchema.parse( '000' ) ).toBe( 0 );
-            expect( timeStringSchema.parse( ' 33ms' ) ).toBe( 33 );
+            expect( zodTimeString.parse( ' 100ms ' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '  5  h  ' ) ).toBe( 18000000 );
+            expect( zodTimeString.parse( '  1000  ' ) ).toBe( 1000 );
+            expect( zodTimeString.parse( '   1000000' ) ).toBe( 1000000 );
+            expect( zodTimeString.parse( '000' ) ).toBe( 0 );
+            expect( zodTimeString.parse( ' 33ms' ) ).toBe( 33 );
         } );
     } );
 
     describe( 'unit variations', () => {
         test( 'should recognize millisecond variations', () => {
-            expect( timeStringSchema.parse( '100ms' ) ).toBe( 100 );
-            expect( timeStringSchema.parse( '100msec' ) ).toBe( 100 );
-            expect( timeStringSchema.parse( '100msecs' ) ).toBe( 100 );
-            expect( timeStringSchema.parse( '100millisecond' ) ).toBe( 100 );
-            expect( timeStringSchema.parse( '100milliseconds' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '100ms' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '100msec' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '100msecs' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '100millisecond' ) ).toBe( 100 );
+            expect( zodTimeString.parse( '100milliseconds' ) ).toBe( 100 );
         } );
 
         test( 'should recognize second variations', () => {
-            expect( timeStringSchema.parse( '5s' ) ).toBe( 5000 );
-            expect( timeStringSchema.parse( '5sec' ) ).toBe( 5000 );
-            expect( timeStringSchema.parse( '5secs' ) ).toBe( 5000 );
-            expect( timeStringSchema.parse( '5second' ) ).toBe( 5000 );
-            expect( timeStringSchema.parse( '5seconds' ) ).toBe( 5000 );
+            expect( zodTimeString.parse( '5s' ) ).toBe( 5000 );
+            expect( zodTimeString.parse( '5sec' ) ).toBe( 5000 );
+            expect( zodTimeString.parse( '5secs' ) ).toBe( 5000 );
+            expect( zodTimeString.parse( '5second' ) ).toBe( 5000 );
+            expect( zodTimeString.parse( '5seconds' ) ).toBe( 5000 );
         } );
 
         test( 'should recognize minute variations', () => {
-            expect( timeStringSchema.parse( '5m' ) ).toBe( 300000 );
-            expect( timeStringSchema.parse( '5min' ) ).toBe( 300000 );
-            expect( timeStringSchema.parse( '5mins' ) ).toBe( 300000 );
-            expect( timeStringSchema.parse( '5minute' ) ).toBe( 300000 );
-            expect( timeStringSchema.parse( '5minutes' ) ).toBe( 300000 );
+            expect( zodTimeString.parse( '5m' ) ).toBe( 300000 );
+            expect( zodTimeString.parse( '5min' ) ).toBe( 300000 );
+            expect( zodTimeString.parse( '5mins' ) ).toBe( 300000 );
+            expect( zodTimeString.parse( '5minute' ) ).toBe( 300000 );
+            expect( zodTimeString.parse( '5minutes' ) ).toBe( 300000 );
         } );
 
         test( 'should recognize hour variations', () => {
-            expect( timeStringSchema.parse( '2h' ) ).toBe( 7200000 );
-            expect( timeStringSchema.parse( '2hr' ) ).toBe( 7200000 );
-            expect( timeStringSchema.parse( '2hrs' ) ).toBe( 7200000 );
-            expect( timeStringSchema.parse( '2hour' ) ).toBe( 7200000 );
-            expect( timeStringSchema.parse( '2hours' ) ).toBe( 7200000 );
+            expect( zodTimeString.parse( '2h' ) ).toBe( 7200000 );
+            expect( zodTimeString.parse( '2hr' ) ).toBe( 7200000 );
+            expect( zodTimeString.parse( '2hrs' ) ).toBe( 7200000 );
+            expect( zodTimeString.parse( '2hour' ) ).toBe( 7200000 );
+            expect( zodTimeString.parse( '2hours' ) ).toBe( 7200000 );
         } );
 
         test( 'should recognize day variations', () => {
-            expect( timeStringSchema.parse( '3d' ) ).toBe( 259200000 );
-            expect( timeStringSchema.parse( '3day' ) ).toBe( 259200000 );
-            expect( timeStringSchema.parse( '3days' ) ).toBe( 259200000 );
+            expect( zodTimeString.parse( '3d' ) ).toBe( 259200000 );
+            expect( zodTimeString.parse( '3day' ) ).toBe( 259200000 );
+            expect( zodTimeString.parse( '3days' ) ).toBe( 259200000 );
         } );
 
         test( 'should recognize month variations', () => {
-            expect( timeStringSchema.parse( '2mo' ) ).toBe( 5184000000 );
-            expect( timeStringSchema.parse( '2mth' ) ).toBe( 5184000000 );
-            expect( timeStringSchema.parse( '2month' ) ).toBe( 5184000000 );
-            expect( timeStringSchema.parse( '2months' ) ).toBe( 5184000000 );
+            expect( zodTimeString.parse( '2mo' ) ).toBe( 5184000000 );
+            expect( zodTimeString.parse( '2mth' ) ).toBe( 5184000000 );
+            expect( zodTimeString.parse( '2month' ) ).toBe( 5184000000 );
+            expect( zodTimeString.parse( '2months' ) ).toBe( 5184000000 );
         } );
 
         test( 'should recognize year variations', () => {
-            expect( timeStringSchema.parse( '1y' ) ).toBe( 31536000000 );
-            expect( timeStringSchema.parse( '1yr' ) ).toBe( 31536000000 );
-            expect( timeStringSchema.parse( '1yrs' ) ).toBe( 31536000000 );
-            expect( timeStringSchema.parse( '1year' ) ).toBe( 31536000000 );
-            expect( timeStringSchema.parse( '1years' ) ).toBe( 31536000000 );
+            expect( zodTimeString.parse( '1y' ) ).toBe( 31536000000 );
+            expect( zodTimeString.parse( '1yr' ) ).toBe( 31536000000 );
+            expect( zodTimeString.parse( '1yrs' ) ).toBe( 31536000000 );
+            expect( zodTimeString.parse( '1year' ) ).toBe( 31536000000 );
+            expect( zodTimeString.parse( '1years' ) ).toBe( 31536000000 );
         } );
     } );
 
     describe( 'edge cases', () => {
         test( 'should handle decimal values', () => {
-            expect( timeStringSchema.parse( '1.5h' ) ).toBe( 5400000 );
-            expect( timeStringSchema.parse( '0.5d' ) ).toBe( 43200000 );
-            expect( timeStringSchema.parse( '.5m' ) ).toBe( 30000 );
+            expect( zodTimeString.parse( '1.5h' ) ).toBe( 5400000 );
+            expect( zodTimeString.parse( '0.5d' ) ).toBe( 43200000 );
+            expect( zodTimeString.parse( '.5m' ) ).toBe( 30000 );
         } );
 
         test( 'should handle negative values', () => {
-            expect( timeStringSchema.parse( '-1h' ) ).toBe( -3600000 );
-            expect( timeStringSchema.parse( '-5m' ) ).toBe( -300000 );
-            expect( timeStringSchema.parse( '-100ms' ) ).toBe( -100 );
+            expect( zodTimeString.parse( '-1h' ) ).toBe( -3600000 );
+            expect( zodTimeString.parse( '-5m' ) ).toBe( -300000 );
+            expect( zodTimeString.parse( '-100ms' ) ).toBe( -100 );
         } );
 
         test( 'should handle case insensitivity', () => {
-            expect( timeStringSchema.parse( '5M' ) ).toBe( 300000 );
-            expect( timeStringSchema.parse( '5H' ) ).toBe( 18000000 );
-            expect( timeStringSchema.parse( '5MS' ) ).toBe( 5 );
+            expect( zodTimeString.parse( '5M' ) ).toBe( 300000 );
+            expect( zodTimeString.parse( '5H' ) ).toBe( 18000000 );
+            expect( zodTimeString.parse( '5MS' ) ).toBe( 5 );
         } );
     } );
 
     describe( 'error handling', () => {
         test( 'should throw for invalid formats', () => {
-            expect( () => timeStringSchema.parse( 'abc' ) ).toThrow();
-            expect( () => timeStringSchema.parse( '123abc' ) ).toThrow();
-            expect( () => timeStringSchema.parse( 'ms' ) ).toThrow();
+            expect( () => zodTimeString.parse( 'abc' ) ).toThrow();
+            expect( () => zodTimeString.parse( '123abc' ) ).toThrow();
+            expect( () => zodTimeString.parse( 'ms' ) ).toThrow();
         } );
 
         test( 'should throw for invalid units', () => {
-            expect( () => timeStringSchema.parse( '5z' ) ).toThrow();
-            expect( () => timeStringSchema.parse( '10invalid' ) ).toThrow();
+            expect( () => zodTimeString.parse( '5z' ) ).toThrow();
+            expect( () => zodTimeString.parse( '10invalid' ) ).toThrow();
         } );
 
         test( 'should throw for invalid time values', () => {
-            expect( () => timeStringSchema.parse( "don't" ) ).toThrow();
-            expect( () => timeStringSchema.parse( 'd' ) ).toThrow();
+            expect( () => zodTimeString.parse( "don't" ) ).toThrow();
+            expect( () => zodTimeString.parse( 'd' ) ).toThrow();
         } );
     } );
 
@@ -124,85 +124,85 @@ describe( 'timeStringSchema', () => {
     describe( 'chainable validation methods', () => {
         describe( 'positive()', () => {
             test( 'should accept positive values', () => {
-                expect( timeStringSchema.positive().parse( '100ms' ) ).toBe( 100 );
-                expect( timeStringSchema.positive().parse( '1s' ) ).toBe( 1000 );
-                expect( timeStringSchema.positive().parse( '5m' ) ).toBe( 300000 );
+                expect( zodTimeString.positive().parse( '100ms' ) ).toBe( 100 );
+                expect( zodTimeString.positive().parse( '1s' ) ).toBe( 1000 );
+                expect( zodTimeString.positive().parse( '5m' ) ).toBe( 300000 );
             } );
 
             test( 'should reject zero values', () => {
-                expect( () => timeStringSchema.positive().parse( '0ms' ) ).toThrow();
-                expect( () => timeStringSchema.positive().parse( '0' ) ).toThrow();
+                expect( () => zodTimeString.positive().parse( '0ms' ) ).toThrow();
+                expect( () => zodTimeString.positive().parse( '0' ) ).toThrow();
             } );
 
             test( 'should reject negative values', () => {
-                expect( () => timeStringSchema.positive().parse( '-100ms' ) ).toThrow();
-                expect( () => timeStringSchema.positive().parse( '-1s' ) ).toThrow();
-                expect( () => timeStringSchema.positive().parse( '-5m' ) ).toThrow();
+                expect( () => zodTimeString.positive().parse( '-100ms' ) ).toThrow();
+                expect( () => zodTimeString.positive().parse( '-1s' ) ).toThrow();
+                expect( () => zodTimeString.positive().parse( '-5m' ) ).toThrow();
             } );
         } );
 
         describe( 'negative()', () => {
             test( 'should accept negative values', () => {
-                expect( timeStringSchema.negative().parse( '-100ms' ) ).toBe( -100 );
-                expect( timeStringSchema.negative().parse( '-1s' ) ).toBe( -1000 );
-                expect( timeStringSchema.negative().parse( '-5m' ) ).toBe( -300000 );
+                expect( zodTimeString.negative().parse( '-100ms' ) ).toBe( -100 );
+                expect( zodTimeString.negative().parse( '-1s' ) ).toBe( -1000 );
+                expect( zodTimeString.negative().parse( '-5m' ) ).toBe( -300000 );
             } );
 
             test( 'should reject zero values', () => {
-                expect( () => timeStringSchema.negative().parse( '0ms' ) ).toThrow();
-                expect( () => timeStringSchema.negative().parse( '0' ) ).toThrow();
+                expect( () => zodTimeString.negative().parse( '0ms' ) ).toThrow();
+                expect( () => zodTimeString.negative().parse( '0' ) ).toThrow();
             } );
 
             test( 'should reject positive values', () => {
-                expect( () => timeStringSchema.negative().parse( '100ms' ) ).toThrow();
-                expect( () => timeStringSchema.negative().parse( '1s' ) ).toThrow();
-                expect( () => timeStringSchema.negative().parse( '5m' ) ).toThrow();
+                expect( () => zodTimeString.negative().parse( '100ms' ) ).toThrow();
+                expect( () => zodTimeString.negative().parse( '1s' ) ).toThrow();
+                expect( () => zodTimeString.negative().parse( '5m' ) ).toThrow();
             } );
         } );
 
         describe( 'min()', () => {
             test( 'should accept values greater than minimum', () => {
-                expect( timeStringSchema.min( 100 ).parse( '200ms' ) ).toBe( 200 );
-                expect( timeStringSchema.min( 1000 ).parse( '2s' ) ).toBe( 2000 );
-                expect( timeStringSchema.min( -200 ).parse( '-100ms' ) ).toBe( -100 );
+                expect( zodTimeString.min( 100 ).parse( '200ms' ) ).toBe( 200 );
+                expect( zodTimeString.min( 1000 ).parse( '2s' ) ).toBe( 2000 );
+                expect( zodTimeString.min( -200 ).parse( '-100ms' ) ).toBe( -100 );
             } );
 
             test( 'should accept values equal to minimum', () => {
-                expect( timeStringSchema.min( 100 ).parse( '100ms' ) ).toBe( 100 );
-                expect( timeStringSchema.min( 1000 ).parse( '1s' ) ).toBe( 1000 );
-                expect( timeStringSchema.min( -100 ).parse( '-100ms' ) ).toBe( -100 );
+                expect( zodTimeString.min( 100 ).parse( '100ms' ) ).toBe( 100 );
+                expect( zodTimeString.min( 1000 ).parse( '1s' ) ).toBe( 1000 );
+                expect( zodTimeString.min( -100 ).parse( '-100ms' ) ).toBe( -100 );
             } );
 
             test( 'should reject values less than minimum', () => {
-                expect( () => timeStringSchema.min( 100 ).parse( '50ms' ) ).toThrow();
-                expect( () => timeStringSchema.min( 2000 ).parse( '1s' ) ).toThrow();
-                expect( () => timeStringSchema.min( -100 ).parse( '-200ms' ) ).toThrow();
+                expect( () => zodTimeString.min( 100 ).parse( '50ms' ) ).toThrow();
+                expect( () => zodTimeString.min( 2000 ).parse( '1s' ) ).toThrow();
+                expect( () => zodTimeString.min( -100 ).parse( '-200ms' ) ).toThrow();
             } );
         } );
 
         describe( 'max()', () => {
             test( 'should accept values less than maximum', () => {
-                expect( timeStringSchema.max( 100 ).parse( '50ms' ) ).toBe( 50 );
-                expect( timeStringSchema.max( 2000 ).parse( '1s' ) ).toBe( 1000 );
-                expect( timeStringSchema.max( -100 ).parse( '-200ms' ) ).toBe( -200 );
+                expect( zodTimeString.max( 100 ).parse( '50ms' ) ).toBe( 50 );
+                expect( zodTimeString.max( 2000 ).parse( '1s' ) ).toBe( 1000 );
+                expect( zodTimeString.max( -100 ).parse( '-200ms' ) ).toBe( -200 );
             } );
 
             test( 'should accept values equal to maximum', () => {
-                expect( timeStringSchema.max( 100 ).parse( '100ms' ) ).toBe( 100 );
-                expect( timeStringSchema.max( 1000 ).parse( '1s' ) ).toBe( 1000 );
-                expect( timeStringSchema.max( -100 ).parse( '-100ms' ) ).toBe( -100 );
+                expect( zodTimeString.max( 100 ).parse( '100ms' ) ).toBe( 100 );
+                expect( zodTimeString.max( 1000 ).parse( '1s' ) ).toBe( 1000 );
+                expect( zodTimeString.max( -100 ).parse( '-100ms' ) ).toBe( -100 );
             } );
 
             test( 'should reject values greater than maximum', () => {
-                expect( () => timeStringSchema.max( 100 ).parse( '200ms' ) ).toThrow();
-                expect( () => timeStringSchema.max( 1000 ).parse( '2s' ) ).toThrow();
-                expect( () => timeStringSchema.max( -200 ).parse( '-100ms' ) ).toThrow();
+                expect( () => zodTimeString.max( 100 ).parse( '200ms' ) ).toThrow();
+                expect( () => zodTimeString.max( 1000 ).parse( '2s' ) ).toThrow();
+                expect( () => zodTimeString.max( -200 ).parse( '-100ms' ) ).toThrow();
             } );
         } );
 
         describe( 'chaining validation methods', () => {
             test( 'should allow chaining positive() with min() and max()', () => {
-                const schema = timeStringSchema.positive().min( 1000 ).max( 10000 );
+                const schema = zodTimeString.positive().min( 1000 ).max( 10000 );
 
                 expect( schema.parse( '1s' ) ).toBe( 1000 );
                 expect( schema.parse( '5s' ) ).toBe( 5000 );
@@ -214,7 +214,7 @@ describe( 'timeStringSchema', () => {
             } );
 
             test( 'should allow chaining negative() with min() and max()', () => {
-                const schema = timeStringSchema.negative().min( -10000 ).max( -1000 );
+                const schema = zodTimeString.negative().min( -10000 ).max( -1000 );
 
                 expect( schema.parse( '-1s' ) ).toBe( -1000 );
                 expect( schema.parse( '-5s' ) ).toBe( -5000 );
@@ -232,7 +232,7 @@ describe( 'timeStringSchema', () => {
         describe( 'base validation error messages', () => {
             test( 'should support custom format error message with string', () => {
                 const customMsg = 'Custom format error';
-                const schema = timeStringSchema.withErrorMessages( {
+                const schema = zodTimeString.withErrorMessages( {
                     invalidFormatError: customMsg
                 } );
 
@@ -246,7 +246,7 @@ describe( 'timeStringSchema', () => {
 
             test( 'should support custom format error message with object', () => {
                 const customMsg = 'Custom format error with object';
-                const schema = timeStringSchema.withErrorMessages( {
+                const schema = zodTimeString.withErrorMessages( {
                     invalidFormatError: { message: customMsg }
                 } );
 
@@ -260,7 +260,7 @@ describe( 'timeStringSchema', () => {
 
             test( 'should support custom value error message', () => {
                 const customMsg = 'Custom value error';
-                const schema = timeStringSchema.withErrorMessages( {
+                const schema = zodTimeString.withErrorMessages( {
                     invalidValueError: customMsg
                 } );
 
@@ -284,7 +284,7 @@ describe( 'timeStringSchema', () => {
             test( 'should support multiple custom error message options', () => {
                 const formatMsg = 'Custom format error';
                 const valueMsg = 'Custom value error';
-                const schema = timeStringSchema.withErrorMessages( {
+                const schema = zodTimeString.withErrorMessages( {
                     invalidFormatError: formatMsg,
                     invalidValueError: valueMsg
                 } );
@@ -303,7 +303,7 @@ describe( 'timeStringSchema', () => {
 
             test( 'should support function-based format error message', () => {
                 const formatErrorFn = ( invalid: string ) => `The format "${ invalid }" is not valid`;
-                const schema = timeStringSchema.withErrorMessages( {
+                const schema = zodTimeString.withErrorMessages( {
                     invalidFormatError: formatErrorFn
                 } );
 
@@ -317,7 +317,7 @@ describe( 'timeStringSchema', () => {
 
             test( 'should support function-based format error message in object', () => {
                 const formatErrorFn = ( invalid: string ) => `Invalid format: ${ invalid }`;
-                const schema = timeStringSchema.withErrorMessages( {
+                const schema = zodTimeString.withErrorMessages( {
                     invalidFormatError: { message: formatErrorFn }
                 } );
 
@@ -331,7 +331,7 @@ describe( 'timeStringSchema', () => {
 
             test( 'should support function-based unit error message', () => {
                 const unitErrorFn = ( invalid: string ) => `The unit "${ invalid }" is not supported`;
-                const schema = timeStringSchema.withErrorMessages( {
+                const schema = zodTimeString.withErrorMessages( {
                     invalidUnitError: unitErrorFn
                 } );
 
@@ -350,7 +350,7 @@ describe( 'timeStringSchema', () => {
                 const customMsg = 'Must be a positive value';
 
                 try {
-                    timeStringSchema.positive( customMsg ).parse( '0ms' );
+                    zodTimeString.positive( customMsg ).parse( '0ms' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     // Verify that an error was thrown, but don't check the specific message
@@ -362,7 +362,7 @@ describe( 'timeStringSchema', () => {
                 const customMsg = 'Must be a positive value (object)';
 
                 try {
-                    timeStringSchema.positive( { message: customMsg } ).parse( '-1s' );
+                    zodTimeString.positive( { message: customMsg } ).parse( '-1s' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     // Verify that an error was thrown, but don't check the specific message
@@ -374,7 +374,7 @@ describe( 'timeStringSchema', () => {
                 const customMsg = 'Must be a negative value';
 
                 try {
-                    timeStringSchema.negative( customMsg ).parse( '1s' );
+                    zodTimeString.negative( customMsg ).parse( '1s' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     expect( error.issues[ 0 ].message ).toBe( customMsg );
@@ -385,7 +385,7 @@ describe( 'timeStringSchema', () => {
                 const customMsg = 'Must be at least 1000ms';
 
                 try {
-                    timeStringSchema.min( 1000, customMsg ).parse( '500ms' );
+                    zodTimeString.min( 1000, customMsg ).parse( '500ms' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     expect( error.issues[ 0 ].message ).toBe( customMsg );
@@ -396,7 +396,7 @@ describe( 'timeStringSchema', () => {
                 const customMsg = 'Must be at most 1000ms';
 
                 try {
-                    timeStringSchema.max( 1000, customMsg ).parse( '2000ms' );
+                    zodTimeString.max( 1000, customMsg ).parse( '2000ms' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     expect( error.issues[ 0 ].message ).toBe( customMsg );
@@ -408,7 +408,7 @@ describe( 'timeStringSchema', () => {
                 const minMsg = 'Must be at least 1000ms';
                 const maxMsg = 'Must be at most 10000ms';
 
-                const schema = timeStringSchema
+                const schema = zodTimeString
                     .positive( positiveMsg )
                     .min( 1000, minMsg )
                     .max( 10000, maxMsg );
@@ -442,7 +442,7 @@ describe( 'timeStringSchema', () => {
                 const positiveFn = ( invalid: string ) => `Value ${ invalid } must be positive`;
 
                 try {
-                    timeStringSchema.positive( positiveFn ).parse( '-5s' );
+                    zodTimeString.positive( positiveFn ).parse( '-5s' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     // Verify that an error was thrown, but don't check the specific message format
@@ -454,7 +454,7 @@ describe( 'timeStringSchema', () => {
                 const negativeFn = ( invalid: string ) => `Value ${ invalid } must be negative`;
 
                 try {
-                    timeStringSchema.negative( negativeFn ).parse( '5s' );
+                    zodTimeString.negative( negativeFn ).parse( '5s' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     // Verify that an error was thrown, but don't check the specific message format
@@ -466,7 +466,7 @@ describe( 'timeStringSchema', () => {
                 const minFn = ( invalid: string ) => `Value ${ invalid } is below the minimum of 1000`;
 
                 try {
-                    timeStringSchema.min( 1000, minFn ).parse( '500ms' );
+                    zodTimeString.min( 1000, minFn ).parse( '500ms' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     // Verify that an error was thrown, but don't check the specific message format
@@ -478,7 +478,7 @@ describe( 'timeStringSchema', () => {
                 const maxFn = ( invalid: string ) => `Value ${ invalid } exceeds the maximum of 1000`;
 
                 try {
-                    timeStringSchema.max( 1000, maxFn ).parse( '2000ms' );
+                    zodTimeString.max( 1000, maxFn ).parse( '2000ms' );
                     fail( 'Should have thrown an error' );
                 } catch ( error: any ) {
                     // Verify that an error was thrown, but don't check the specific message format
@@ -491,7 +491,7 @@ describe( 'timeStringSchema', () => {
                 const minFn = ( invalid: string ) => `Too small: ${ invalid }`;
                 const maxFn = ( invalid: string ) => `Too large: ${ invalid }`;
 
-                const schema = timeStringSchema
+                const schema = zodTimeString
                     .positive( positiveFn )
                     .min( 1000, minFn )
                     .max( 10000, maxFn );


### PR DESCRIPTION
BREAKING CHANGE: timeStringSchema is now changed to zodTimeString. Also, the package now supports default import for shortening as zts.